### PR TITLE
Add support for injected lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ language tree (see
 - `handlebars`
 - `glimmer`
 - `graphql`
+- `lua`
 
 This means that in any filetype, if the given languages are injected, this 
 plugin should detect them and correctly set the `commentstring`. For example, 

--- a/lua/ts_context_commentstring/internal.lua
+++ b/lua/ts_context_commentstring/internal.lua
@@ -26,6 +26,7 @@ M.config = {
   handlebars = '{{! %s }}',
   glimmer = '{{! %s }}',
   graphql = '# %s',
+  lua = '-- %s',
 
   -- Languages that can have multiple types of comments
   tsx = {


### PR DESCRIPTION
Closes #8

Now that https://github.com/nvim-treesitter/nvim-treesitter/pull/1198
has added support for VimL, we can add support for injected lua.