### PR TITLE
Add support for requesting multi-line comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,29 @@ rest of the keys refer to the type of the treesitter node. In this example, if
 your cursor is inside a `jsx_element`, then the `{/* %s */}` `commentstring` 
 will be set.
 
+Finally, it is possible to have each `commentstring` configuration be a table 
+with custom keys. This can be used to configure separate single and multi-line 
+comment styles (useful when integrating with a commenting plugin):
+
+```lua
+require'nvim-treesitter.configs'.setup {
+  context_commentstring = {
+    enable = true,
+    config = {
+      typescript = { __default = '// %s', __multiline = '/* %s */' }
+    }
+  }
+}
+```
+
+Then, the custom key can be passed to `update_commentstring`:
+
+```lua
+require('ts_context_commentstring.internal').update_commentstring({
+  key = '__multiline',
+})
+```
+
 Note that the language refers to the *treesitter* language, not the filetype or 
 the file extension.
 

--- a/README.md
+++ b/README.md
@@ -264,6 +264,35 @@ require("nvim_comment").setup({
 })
 ```
 
+#### [`Comment.nvim`](https://github.com/numToStr/Comment.nvim)
+
+First, disable the `CursorHold` autocommand of this plugin:
+
+```lua
+require'nvim-treesitter.configs'.setup {
+  context_commentstring = {
+    enable = true,
+    enable_autocmd = false,
+  }
+}
+```
+
+Then, configure `Comment.nvim` to trigger the `commentstring` updating logic 
+with its `pre_hook` configuration:
+
+```lua
+require('Comment').setup {
+  pre_hook = function(ctx)
+    local U = require 'Comment.utils'
+    local type = ctx.ctype == U.ctype.line and '__default' or '__multiline'
+    return require('ts_context_commentstring.internal').calculate_commentstring {
+      key = type,
+    }
+  end,
+}
+```
+
+
 ## More demos
 
 **React:**


### PR DESCRIPTION
This is useful if a commenting plugin enables commenting a region that is not the full line. Currently, only [Comment.nvim](https://github.com/numToStr/Comment.nvim/) seems to support this.

For example, typing `gciw` in a TypeScript file here:

    hello world!
            ^ cursor

Would result in this:

    hello /* world */!

And not this:

    // hello world!

The way we support it is to allow each `commentstring` configuration value to be a table with custom keys. Afterwards, the custom key can be passed to `update_commentstring` so that the `commentstring` returned matches the requested one if possible.

```lua
require'nvim-treesitter.configs'.setup {
  context_commentstring = {
    enable = true,
    config = {
      typescript = { __default = '// %s', __multiline = '/* %s */' }
    }
  }
}
```

Later, the `__multiline` comment is returned (if available) with:

```lua
require('ts_context_commentstring.internal').update_commentstring({
  key = '__multiline',
})
```

Here is how it can be configured with `Comment.nvim`:

```lua
require('Comment').setup {
  pre_hook = function(ctx)
    local U = require 'Comment.utils'
    local type = ctx.ctype == U.ctype.line and '__default' or '__multiline'
    return require('ts_context_commentstring.internal').calculate_commentstring {
      key = type,
    }
  end,
}
```

This feature was requested in https://github.com/numToStr/Comment.nvim/issues/10