### PR TITLE
Allow customizing tree traversal start location

### DIFF
--- a/lua/ts_context_commentstring/internal.lua
+++ b/lua/ts_context_commentstring/internal.lua
@@ -84,8 +84,9 @@ end
 function M.calculate_commentstring(args)
   args = args or {}
   local key = args.key or '__default'
+  local location = args.location or nil
 
-  local node, language_tree = utils.get_node_at_cursor_start_of_line(vim.tbl_keys(M.config))
+  local node, language_tree = utils.get_node_at_cursor_start_of_line(vim.tbl_keys(M.config), location)
 
   if not node and not language_tree then
     return nil


### PR DESCRIPTION
Make it possible to configure where the `commentstring` detection logic starts in the treesitter AST. The default is to start at the start of the cursor's line (first non-blank character). However, this is not 100% correct when commenting with motions.

`update_commentstring` now accepts a location where to start the analysis so that when integrating with a commenting plugin, more granular control is possible.

Additionally, a few useful helper functions are exported from `ts_context_commentstring.utils` which make it simpler to pass in a location.

Resolves #27