### PR TITLE
Add pre_hook function for calculating commentstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,23 @@ require('ts_context_commentstring.internal').calculate_commentstring {
 }
 ```
 
+If you want to calculate your own `commentstring` you are able to do so with
+the `pre_hook`.
+```lua
+require'nvim-treesitter.configs'.setup {
+  context_commentstring = {
+    enable = true,
+    pre_hook = function(node, language_tree)
+        ...
+    end
+  }
+}
+```
+This is a function that takes in the current node and the language tree which
+could be used for context like figuring out which language you should use a 
+commentstring for. You can also for example figure out which type the current
+node is. You need to return a commentstring in the `pre_hook`if you want it to 
+be set.
 
 ### Behavior
 

--- a/lua/ts_context_commentstring/internal.lua
+++ b/lua/ts_context_commentstring/internal.lua
@@ -118,6 +118,14 @@ function M.calculate_commentstring(args)
     return nil
   end
 
+  local pre_hook = configs.get_module('context_commentstring').pre_hook
+  if pre_hook then
+    local commentstring = pre_hook(node, language_tree)
+    if commentstring then
+      return commentstring
+    end
+  end
+
   local language = language_tree:lang()
   local language_config = M.config[language]
 


### PR DESCRIPTION
So I have overridden update_commentstring for a few weeks now to be able to calculate a commentstring before doing the comment. However, I don't like that I have to override the entire function and really only want a pre_hook that takes precedence over the internal `calculate_commentstring`. 

So the reason I want this, is to be able to for example uncomment different commentstrings without manually changing. Let's take an example for C. In C you can comment with a comentstring of `// %s` and `/* %s */`.

I have configured the commentstring to be `// %s` but if i encounter a comment with `/* %s */` I have to uncomment it manually. For the pre-hook I then want to parse the current line and see which commentstring is used and then based on that maybe switch the commentstring before uncommenting. Therefore I have chosen to pass in the current node and tree as argument to the `pre_hook` to give the user some context to be able to easily get the language and the type of the node which I would like to use.

I am not entirely sure if I did it correct with the comments on `@param` over the function, so If this is wrong I would be happy to fix this with your assistance! 