### PR TITLE
Fix comment string inside JSX spread element

### DIFF
--- a/lua/ts_context_commentstring/internal.lua
+++ b/lua/ts_context_commentstring/internal.lua
@@ -70,6 +70,7 @@ M.config = {
     comment = { __default = '// %s', __multiline = '/* %s */' },
     call_expression = { __default = '// %s', __multiline = '/* %s */' },
     statement_block = { __default = '// %s', __multiline = '/* %s */' },
+    spread_element = { __default = '// %s', __multiline = '/* %s */' },
   },
 }
 

--- a/lua/ts_context_commentstring/internal.lua
+++ b/lua/ts_context_commentstring/internal.lua
@@ -60,6 +60,7 @@ M.config = {
     comment = { __default = '// %s', __multiline = '/* %s */' },
     call_expression = { __default = '// %s', __multiline = '/* %s */' },
     statement_block = { __default = '// %s', __multiline = '/* %s */' },
+    spread_element = { __default = '// %s', __multiline = '/* %s */' },
   },
   javascript = {
     __default = '// %s',


### PR DESCRIPTION
Fixes #38

I think this change is probably safe, even though it theoretically matches all spread elements, not just those in JSX blocks. If not, it's probably blocked until there's something like a `__parent` node selector.