### PR TITLE
Add option to disable default commentary mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,16 @@ If `vim-commentary` is detected, then this plugin automatically sets up
 `vim-commentary` mappings to first update the `commentstring`, and then trigger 
 `vim-commentary`.
 
+If you don't use default mappings, you can disable them:
+
+```lua
+require'nvim-treesitter.configs'.setup {
+  context_commentstring = {
+    enable = true,
+    disable_commentary_mappings = true,
+  }
+}
+```
 
 #### [`kommentary`](https://github.com/b3nj5m1n/kommentary)
 

--- a/lua/ts_context_commentstring/internal.lua
+++ b/lua/ts_context_commentstring/internal.lua
@@ -81,13 +81,16 @@ function M.setup_buffer()
   -- is no match
   api.nvim_buf_set_var(0, 'ts_original_commentstring', api.nvim_buf_get_option(0, 'commentstring'))
 
-  local enable_autocmd = configs.get_module('context_commentstring').enable_autocmd
+  local plugin_config = configs.get_module 'context_commentstring'
+  local enable_autocmd = plugin_config.enable_autocmd
   enable_autocmd = enable_autocmd == nil and true or enable_autocmd
 
   -- If vim-commentary is installed, set up mappings for it
   if vim.g.loaded_commentary == 1 then
     enable_autocmd = false
-    require('ts_context_commentstring.integrations.vim_commentary').set_up_maps()
+    if not plugin_config.disable_commentary_mappings then
+      require('ts_context_commentstring.integrations.vim_commentary').set_up_maps()
+    end
   end
 
   if enable_autocmd then


### PR DESCRIPTION
I use commentary.vim, but I don't use mappings like `gcc`.
It would be nice if default mappings can be disabled.