### PR TITLE
fix(Comment.nvim): calculating multiline commentsring

### DIFF
--- a/lua/ts_context_commentstring/integrations/comment_nvim.lua
+++ b/lua/ts_context_commentstring/integrations/comment_nvim.lua
@@ -30,7 +30,10 @@ function M.create_pre_hook()
     -- Determine the location where to calculate commentstring from
     local location = nil
     if ctx.ctype == U.ctype.blockwise then
-      location = require('ts_context_commentstring.utils').get_cursor_location()
+      location = {
+        ctx.range.srow - 1,
+        ctx.range.scol,
+      }
     elseif ctx.cmotion == U.cmotion.v or ctx.cmotion == U.cmotion.V then
       location = require('ts_context_commentstring.utils').get_visual_start_location()
     end

--- a/lua/ts_context_commentstring/utils.lua
+++ b/lua/ts_context_commentstring/utils.lua
@@ -3,6 +3,8 @@ local fn = vim.fn
 
 local parsers = require 'nvim-treesitter.parsers'
 
+---Coordinates for a location. Both the line and the column are 0-indexed (e.g.,
+---line nr 10 is line 9, the first column is 0).
 ---@alias ts_context_commentstring.Location number[] 2-tuple of (line, column)
 
 local M = {}


### PR DESCRIPTION
The `commentstring` was calculated from the cursor location when doing a blockwise comment with Comment.nvim. Usually, this did not cause any issues. However, with some specific configuration, in JSX, the following case was incorrect:

```jsx
<div>
  {/* <h1>Hello</h1>
  <span>World</span> */}
</div>
```

When visually selecting both commented lines, leaving the cursor on the bottom line would cause the `commentstring` calculation to return `/* %s */`, resulting in:

```jsx
<div>
  /* {/* <h1>Hello</h1>
  <span>World</span> */} */
</div>
```

Now, we're using the selection start coordinates directly from Comment.nvim context, which always triggers the `commentstring` calculating from the start of the visual selection, rather than the cursor location.

Fixes #52