### PR TITLE
Add `Plug` bindings to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,17 @@ require'nvim-treesitter.configs'.setup {
 }
 ```
 
+Alternatively, update your mappings to include the `Context` prefix
+
+```lua
+vim.keymap.set(
+  "n",
+  "g/",
+  '<Plug>ContextCommentaryLine', -- Previously '<Plug>CommentaryLine'
+  { silent = true, desc = "Comment line" }
+)
+```
+
 #### [`kommentary`](https://github.com/b3nj5m1n/kommentary)
 
 `kommentary` can also trigger the `commentstring` updating logic before 


### PR DESCRIPTION
Hey there, thanks for the plugin!

I've been using the following mappings with vim-commentary prior to using this plugin

```lua
vim.keymap.set(
  "n",
  "g/",
  '<Plug>CommentaryLine',
  { silent = true, desc = "Comment line" }
)
vim.keymap.set(
  "v",
  "g/",
  "<Plug>Commentary",
  { silent = true, desc = "Comment selection" }
)
```

At first, I tried using the `commentary_integration` option but because mappings apply to all modes (`n`, `v`, etc), it wasn't an option for me. 

After looking through the code, I found it's a lot easier to just replace `<Plug>Commentary[...]` with `<Plug>ContextCommentary[...]` in my bindings.


```lua
vim.keymap.set(
  "n",
  "g/",
  '<Plug>ContextCommentaryLine',
  { silent = true, desc = "Comment line" }
)
vim.keymap.set(
  "v",
  "g/",
  "<Plug>ContextCommentary",
  { silent = true, desc = "Comment selection" }
)
```

I thought this might be useful for others to know - hence the PR 😄 

