### PR TITLE
Added comment symbol for SQL files

### DIFF
--- a/doc/nvim-ts-context-commentstring.txt
+++ b/doc/nvim-ts-context-commentstring.txt
@@ -28,6 +28,7 @@ language tree (see `lua/ts_context_commentstring/internal.lua`):
 - `python`
 - `rescript`
 - `scss`
+- `sql`
 - `svelte`
 - `tsx`
 - `twig`

--- a/lua/ts_context_commentstring/internal.lua
+++ b/lua/ts_context_commentstring/internal.lua
@@ -50,6 +50,7 @@ M.config = {
   graphql = '# %s',
   lua = { __default = '-- %s', __multiline = '--[[ %s ]]' },
   vim = '" %s',
+  sql = '-- %s',
   twig = '{# %s #}',
   python = { __default = '# %s', __multiline = '""" %s """' },
   nix = { __default = '# %s', __multiline = '/* %s */' },


### PR DESCRIPTION
I added the "--" comment symbol for *.sql files. (I'm not entirely sure whether more sophisticated changes are needed to support commenting in SQL.)