### PR TITLE
docs: fix link to minimal_init.lua example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ require('ts_context_commentstring').setup {}
 > **Note**
 >
 > There is a minimal configuration file available at 
-> [`utils/minimal_init.lua`](./utils/minimal_init.lua) for reference.
+> [`utils/minimal_init.lua`](https://github.com/JoosepAlviste/nvim-ts-context-commentstring/blob/main/utils/minimal_init.lua) for reference.
 
 > **Note**
 >

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ require('ts_context_commentstring').setup {}
 > **Note**
 >
 > There is a minimal configuration file available at 
-> [`utils/minimal_init.lua`](utils/minimal_init.lua) for reference.
+> [`utils/minimal_init.lua`](./utils/minimal_init.lua) for reference.
 
 > **Note**
 >


### PR DESCRIPTION
Clicking the `utils/minimal_init.lua` link in the README when on the homepage <https://github.com/JoosepAlviste/nvim-ts-context-commentstring> takes me to a 404: <https://github.com/JoosepAlviste/utils/minimal_init.lua>, instead of the lua file.

This adds `./` before the filename so it links properly