### PR TITLE
Language additions and sorting filetypes

### DIFF
--- a/doc/nvim-ts-context-commentstring.txt
+++ b/doc/nvim-ts-context-commentstring.txt
@@ -16,6 +16,7 @@ Currently, the following languages are supported when they are injected with
 language tree (see `lua/ts_context_commentstring/internal.lua`):
 
 - `astro`
+- `c`
 - `css`
 - `glimmer`
 - `graphql`
@@ -28,13 +29,16 @@ language tree (see `lua/ts_context_commentstring/internal.lua`):
 - `python`
 - `rescript`
 - `scss`
+- `shell`
 - `sql`
+- `solidity`
 - `svelte`
 - `tsx`
 - `twig`
 - `typescript`
 - `vim`
 - `vue`
+- `zsh`
 
 This means that in any filetype, if the given languages are injected, this 
 plugin should detect them and correctly set the 'commentstring'. For example, 

--- a/doc/nvim-ts-context-commentstring.txt
+++ b/doc/nvim-ts-context-commentstring.txt
@@ -72,13 +72,13 @@ With `nvim-treesitter` >= 1.0, use the `setup` function of this plugin:
 The following examples are for `nvim-treesitter` < 1.0, but they can easily be 
 adapted for `nvim-treesitter` >= 1.0.
 
-Support for more languages can be added quite easily by passing a `config` table
+Support for more languages can be added quite easily by passing a `languages` (formerly the now deprecated `config`) table
 when configuring the plugin:
 >lua
   require('nvim-treesitter.configs').setup {
     context_commentstring = {
       enable = true,
-      config = {
+      languages = {
         css = '// %s',
       },
     },
@@ -88,7 +88,7 @@ when configuring the plugin:
 Or with the `setup` function if using `nvim-treesitter` >= 1.0:
 >lua
   require('ts_context_commentstring').setup {
-    config = {
+    languages = {
       css = '// %s',
     },
   }
@@ -107,7 +107,7 @@ like:
   require('nvim-treesitter.configs').setup {
     context_commentstring = {
       enable = true,
-      config = {
+      languages = {
         javascript = {
           __default = '// %s',
           jsx_element = '{/* %s */}',
@@ -135,7 +135,7 @@ multi-line comment styles (useful when integrating with a commenting plugin):
   require('nvim-treesitter.configs').setup {
     context_commentstring = {
       enable = true,
-      config = {
+      languages = {
         typescript = { __default = '// %s', __multiline = '/* %s */' },
       },
     },

--- a/lua/ts_context_commentstring/config.lua
+++ b/lua/ts_context_commentstring/config.lua
@@ -37,7 +37,7 @@ local M = {}
 ---@class ts_context_commentstring.Config
 ---@field enable_autocmd boolean
 ---@field custom_calculation? fun(node: TSNode, language_tree: LanguageTree): string
----@field config ts_context_commentstring.LanguagesConfig
+---@field languages ts_context_commentstring.LanguagesConfig
 ---@field commentary_integration ts_context_commentstring.CommentaryConfig
 
 ---@type ts_context_commentstring.Config
@@ -56,28 +56,30 @@ M.config = {
     CommentaryUndo = 'gcu',
   },
 
-  -- TODO: We should probably rename this as having a "config" key inside
-  -- "config" is probably confusing. Maybe "languages"?
-  config = {
+  languages = {
     -- Languages that have a single comment style
-    typescript = { __default = '// %s', __multiline = '/* %s */' },
-    css = '/* %s */',
-    scss = { __default = '// %s', __multiline = '/* %s */' },
-    php = { __default = '// %s', __multiline = '/* %s */' },
-    html = '<!-- %s -->',
-    svelte = '<!-- %s -->',
-    vue = '<!-- %s -->',
     astro = '<!-- %s -->',
-    handlebars = '{{! %s }}',
+    c = { __default = '// %s', __multiline = '/* %s */' },
+    css = '/* %s */',
     glimmer = '{{! %s }}',
     graphql = '# %s',
+    handlebars = '{{! %s }}',
+    html = '<!-- %s -->',
     lua = { __default = '-- %s', __multiline = '--[[ %s ]]' },
-    vim = '" %s',
-    sql = '-- %s',
-    twig = '{# %s #}',
-    python = { __default = '# %s', __multiline = '""" %s """' },
     nix = { __default = '# %s', __multiline = '/* %s */' },
+    php = { __default = '// %s', __multiline = '/* %s */' },
+    python = { __default = '# %s', __multiline = '""" %s """' },
     rescript = { __default = '// %s', __multiline = '/* %s */' },
+    scss = { __default = '// %s', __multiline = '/* %s */' },
+    sh = '# %s',
+    solidity = { __default = '// %s', __multiline = '/* %s */' },
+    sql = '-- %s',
+    svelte = '<!-- %s -->',
+    twig = '{# %s #}',
+    typescript = { __default = '// %s', __multiline = '/* %s */' },
+    vim = '" %s',
+    vue = '<!-- %s -->',
+    zsh = '# %s',
 
     -- Languages that can have multiple types of comments
     tsx = {
@@ -94,7 +96,7 @@ M.config = {
   },
 }
 
-M.config.config.javascript = M.config.config.tsx
+M.config.languages.javascript = M.config.languages.tsx
 
 ---@param config? ts_context_commentstring.Config
 function M.update(config)
@@ -113,7 +115,7 @@ end
 
 ---@return ts_context_commentstring.LanguagesConfig
 function M.get_languages_config()
-  return M.config.config
+  return M.config.languages
 end
 
 return M

--- a/lua/ts_context_commentstring/config.lua
+++ b/lua/ts_context_commentstring/config.lua
@@ -38,6 +38,7 @@ local M = {}
 ---@field enable_autocmd boolean
 ---@field custom_calculation? fun(node: TSNode, language_tree: LanguageTree): string
 ---@field languages ts_context_commentstring.LanguagesConfig
+---@field config ts_context_commentstring.LanguagesConfig
 ---@field commentary_integration ts_context_commentstring.CommentaryConfig
 
 ---@type ts_context_commentstring.Config
@@ -94,6 +95,9 @@ M.config = {
       spread_element = { __default = '// %s', __multiline = '/* %s */' },
     },
   },
+
+  ---@deprecated
+  config = {},
 }
 
 M.config.languages.javascript = M.config.languages.tsx
@@ -115,7 +119,7 @@ end
 
 ---@return ts_context_commentstring.LanguagesConfig
 function M.get_languages_config()
-  return M.config.languages
+  return vim.tbl_extend('keep', M.config.languages, M.config.config)
 end
 
 return M

--- a/lua/ts_context_commentstring/config.lua
+++ b/lua/ts_context_commentstring/config.lua
@@ -96,7 +96,7 @@ M.config = {
     },
   },
 
-  ---@deprecated
+  ---@deprecated Use the languages configuration instead!
   config = {},
 }
 
@@ -119,7 +119,7 @@ end
 
 ---@return ts_context_commentstring.LanguagesConfig
 function M.get_languages_config()
-  return vim.tbl_extend('keep', M.config.languages, M.config.config)
+  return vim.tbl_deep_extend('force', M.config.languages, M.config.config)
 end
 
 return M


### PR DESCRIPTION
Wanted to add in some additional language comment types in here as I was lacking some of them myself in my flow using LazyVim! Please let me know if there's anything needed further to get this merged in!

This commit will:
- Add in comment support for:
  - `sh` files
  - `zsh` files
  - `solidity` files
  - `c` files
- Sort all languages in alphabetical order based on filetype/name
- Rename the `config` table inside the `config` to `languages` as written in the TODO above