### PR TITLE
Remove nvim-treesitter, use nvim 0.9+ core utilities

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,12 +8,10 @@ body:
       label: "Minimal reproducible full config"
       description: |
         Please provide a working config based on [this](https://github.com/JoosepAlviste/nvim-ts-context-commentstring/blob/main/utils/minimal_init.lua).
-        **Tip**: You can use `:h $NVIM_APPNAME` to easily set up a second config.
 
-        1. Create a new directory at ~/.config/nvim-test
-        2. Copy the minimal init.lua to that folder
-        3. Run nvim with `NVIM_APPNAME=nvim-test nvim`
-        4. Make the necessary changes to the config file to reproduce your issue
+        1. Clone this plugin somewhere. E.g. `git clone https://github.com/JoosepAlviste/nvim-ts-context-commentstring ~/nvim-repro/nvim-ts-context-commentstring`
+        2. Run `utils/run_minimal.sh` from the cloned repository
+        3. Make the necessary changes to the config file to reproduce your issue
       value: |
         ```lua
         -- Your configuration here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+utils/.testenv

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ plugin.
 
 **Requirements:**
 
-- [Neovim version 0.9](https://github.com/neovim/neovim/releases/tag/v0.9.0)
-- [`nvim-treesitter`](https://github.com/nvim-treesitter/nvim-treesitter)
+- [Neovim version 0.9.4](https://github.com/neovim/neovim/releases/tag/v0.9.4)
+- Tree-sitter parsers (e.g. installed with [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter))
 
 **Installation:**
 
@@ -30,39 +30,21 @@ with [lazy.nvim](https://github.com/folke/lazy.nvim):
 
 ```lua
 require('lazy').setup {
-  {
-    'nvim-treesitter/nvim-treesitter',
-    dependencies = {
-      'JoosepAlviste/nvim-ts-context-commentstring',
-    },
-  },
+  'JoosepAlviste/nvim-ts-context-commentstring',
 }
 ```
 
 **Setup:**
 
-**For `nvim-treesitter` < 1.0**: Enable the module from `nvim-treesitter` setup
+Defaults work out of the box.  
+Set `vim.g.skip_ts_context_commentstring_module = true` somewhere in your configuration to skip backwards compatibility routines and speed up loading.
+
+If you want to change the configuration, call the `setup` function of this plugin, e.g.:
 
 ```lua
-require('nvim-treesitter.configs').setup {
-  -- Install the parsers for the languages you want to comment in
-  -- Here are the supported languages:
-  ensure_installed = {
-    'astro', 'css', 'glimmer', 'graphql', 'handlebars', 'html', 'javascript',
-    'lua', 'nix', 'php', 'python', 'rescript', 'scss', 'svelte', 'tsx', 'twig',
-    'typescript', 'vim', 'vue',
-  },
-
-  context_commentstring = {
-    enable = true,
-  },
+require('ts_context_commentstring').setup {
+  enable_autocmd = false,
 }
-```
-
-**For `nvim-treesitter` >= 1.0**: Call the `setup` function of this plugin:
-
-```lua
-require('ts_context_commentstring').setup {}
 ```
 
 > **Note**

--- a/doc/nvim-ts-context-commentstring.txt
+++ b/doc/nvim-ts-context-commentstring.txt
@@ -50,42 +50,20 @@ should still work.
 ==============================================================================
 3. Commentstring configuration *ts-context-commentstring-commentstring-configuration*
 
+This plugin initializes using default **plugin** system.
 
-This plugin can be configured in two ways. With `nvim-treesitter` < 1.0, the 
-Treesitter module configuration can be used:
->lua
-  require('nvim-treesitter.configs').setup {
-    context_commentstring = {
-      enable = true,
-      -- ... configuration here
-    },
-  }
-<
+If you need to disable auto-initialization, set
+`g:loaded_ts_context_commentstring` to non-zero value.
 
-With `nvim-treesitter` >= 1.0, use the `setup` function of this plugin:
+Custom configuration can be supplied using `setup` function:
 >lua
   require('ts_context_commentstring').setup {
     -- ... configuration here
   }
 <
 
-The following examples are for `nvim-treesitter` < 1.0, but they can easily be 
-adapted for `nvim-treesitter` >= 1.0.
-
 Support for more languages can be added quite easily by passing a `languages` (formerly the now deprecated `config`) table
 when configuring the plugin:
->lua
-  require('nvim-treesitter.configs').setup {
-    context_commentstring = {
-      enable = true,
-      languages = {
-        css = '// %s',
-      },
-    },
-  }
-<
-
-Or with the `setup` function if using `nvim-treesitter` >= 1.0:
 >lua
   require('ts_context_commentstring').setup {
     languages = {
@@ -104,17 +82,14 @@ Treesitter nodes. Each node can have its own unique commenting style. For
 example, here's how the default configuration for `javascript` would look 
 like:
 >lua
-  require('nvim-treesitter.configs').setup {
-    context_commentstring = {
-      enable = true,
-      languages = {
-        javascript = {
-          __default = '// %s',
-          jsx_element = '{/* %s */}',
-          jsx_fragment = '{/* %s */}',
-          jsx_attribute = '// %s',
-          comment = '// %s',
-        },
+  require('ts_context_commentstring').setup {
+    languages = {
+      javascript = {
+        __default = '// %s',
+        jsx_element = '{/* %s */}',
+        jsx_fragment = '{/* %s */}',
+        jsx_attribute = '// %s',
+        comment = '// %s',
       },
     },
   }
@@ -132,12 +107,9 @@ Additionally, it is possible to have each 'commentstring' configuration be a
 table with custom keys. This can be used to configure separate single and 
 multi-line comment styles (useful when integrating with a commenting plugin):
 >lua
-  require('nvim-treesitter.configs').setup {
-    context_commentstring = {
-      enable = true,
-      languages = {
-        typescript = { __default = '// %s', __multiline = '/* %s */' },
-      },
+  require('ts_context_commentstring').setup {
+    languages = {
+      typescript = { __default = '// %s', __multiline = '/* %s */' },
     },
   }
 <
@@ -162,13 +134,10 @@ integrations. There are some useful helper functions exported from
 If you want to calculate your own 'commentstring' you are able to do so with
 the `custom_calculation` option:
 >lua
-  require('nvim-treesitter.configs').setup {
-    context_commentstring = {
-      enable = true,
-      custom_calculation = function(node, language_tree)
-        -- ...
-      end,
-    },
+  require('ts_context_commentstring').setup {
+    custom_calculation = function(node, language_tree)
+      -- ...
+    end,
   }
 <
 

--- a/lua/ts_context_commentstring.lua
+++ b/lua/ts_context_commentstring.lua
@@ -1,37 +1,9 @@
 local M = {}
 
-local status_ok, nvim_ts = pcall(require, 'nvim-treesitter')
-if not status_ok then
-  return
-end
-
-function M.init()
-  if not nvim_ts.define_modules then
-    -- Running nvim-treesitter >= 1.0, modules are no longer a thing
-    return
-  end
-
-  nvim_ts.define_modules {
-    context_commentstring = {
-      module_path = 'ts_context_commentstring.internal',
-    },
-  }
-end
-
----Set up the plugin manually, not as a nvim-treesitter module. This needs to be
----used if using nvim-treesitter 1.0 or above.
+---Set up non-default configuration
 ---@param config ts_context_commentstring.Config
 function M.setup(config)
   require('ts_context_commentstring.config').update(config)
-
-  local group = vim.api.nvim_create_augroup('context_commentstring', { clear = true })
-  vim.api.nvim_create_autocmd('FileType', {
-    group = group,
-    desc = 'Set up nvim-ts-context-commentstring for each buffer that has Treesitter active',
-    callback = function()
-      require('ts_context_commentstring.internal').setup_buffer()
-    end,
-  })
 end
 
 ---Calculate the commentstring based on the current location of the cursor.

--- a/lua/ts_context_commentstring/config.lua
+++ b/lua/ts_context_commentstring/config.lua
@@ -21,10 +21,10 @@ local M = {}
 ---
 ---You can get the treesitter language for the current file by running this
 ---command:
----`:lua print(require'nvim-treesitter.parsers'.get_buf_lang(0))`
+---`:=vim.treesitter.get_parser():lang()`
 ---
 ---Or the injected language for a specific location:
----`:lua print(require'nvim-treesitter.parsers'.get_parser():language_for_range({ line, col, line, col }):lang())`
+---`:=vim.treesitter.get_parser():language_for_range({ line, col, line, col }):lang())`
 ---
 ---@alias ts_context_commentstring.LanguagesConfig table<string, ts_context_commentstring.LanguageConfig>
 

--- a/lua/ts_context_commentstring/config.lua
+++ b/lua/ts_context_commentstring/config.lua
@@ -73,6 +73,7 @@ M.config = {
     rescript = { __default = '// %s', __multiline = '/* %s */' },
     scss = { __default = '// %s', __multiline = '/* %s */' },
     sh = '# %s',
+    bash = '# %s',
     solidity = { __default = '// %s', __multiline = '/* %s */' },
     sql = '-- %s',
     svelte = '<!-- %s -->',

--- a/lua/ts_context_commentstring/internal.lua
+++ b/lua/ts_context_commentstring/internal.lua
@@ -5,15 +5,16 @@ local config = require 'ts_context_commentstring.config'
 
 local M = {}
 
----Initialize the plugin in the current buffer
-function M.setup_buffer()
-  if not utils.is_treesitter_active() then
+---Initialize the plugin in the buffer
+---@param bufnr number
+function M.setup_buffer(bufnr)
+  if not utils.is_treesitter_active(bufnr) then
     return
   end
 
   -- Save the original commentstring so that it can be restored later if there
   -- is no match
-  api.nvim_buf_set_var(0, 'ts_original_commentstring', api.nvim_buf_get_option(0, 'commentstring'))
+  api.nvim_buf_set_var(bufnr, 'ts_original_commentstring', api.nvim_buf_get_option(bufnr, 'commentstring'))
 
   local enable_autocmd = config.is_autocmd_enabled()
 
@@ -25,7 +26,7 @@ function M.setup_buffer()
   if enable_autocmd then
     local group = api.nvim_create_augroup('context_commentstring_ft', { clear = true })
     api.nvim_create_autocmd('CursorHold', {
-      buffer = 0,
+      buffer = bufnr,
       group = group,
       desc = 'Change the commentstring on cursor hold using Treesitter',
       callback = function()
@@ -129,13 +130,18 @@ function M.check_node(node, language_config, commentstring_key)
   return M.check_node(node:parent(), language_config, commentstring_key)
 end
 
----Attach the module to the current buffer
+---@deprecated
 function M.attach()
+  vim.deprecate(
+    'context_commentstring nvim-treesitter module',
+    "use require('ts_context_commentstring').setup {} and set vim.g.skip_ts_context_commentstring_module = true to speed up loading",
+    'in the future',
+    'ts_context_commentstring'
+  )
   config.update(require('nvim-treesitter.configs').get_module 'context_commentstring')
-
-  return M.setup_buffer()
 end
 
+---@deprecated
 function M.detach() end
 
 _G.context_commentstring = {}

--- a/plugin/ts_context_commentstring.lua
+++ b/plugin/ts_context_commentstring.lua
@@ -1,0 +1,30 @@
+if vim.g.loaded_ts_context_commentstring and vim.g.loaded_ts_context_commentstring ~= 0 then
+  return
+end
+
+vim.g.loaded_ts_context_commentstring = 1
+
+local group = vim.api.nvim_create_augroup('ts_context_commentstring', { clear = true })
+vim.api.nvim_create_autocmd('FileType', {
+  group = group,
+  desc = 'Set up nvim-ts-context-commentstring for each buffer that has Treesitter active',
+  callback = function(args)
+    require('ts_context_commentstring.internal').setup_buffer(args.buf)
+  end,
+})
+
+if not vim.g.skip_ts_context_commentstring_module or vim.g.skip_ts_context_commentstring_module == 0 then
+  local nvim_ts_ok, nvim_ts = pcall(require, 'nvim-treesitter')
+  if nvim_ts_ok then
+    if not nvim_ts.define_modules then
+      -- Running nvim-treesitter >= 1.0, modules are no longer a thing
+      return
+    end
+
+    nvim_ts.define_modules {
+      context_commentstring = {
+        module_path = 'ts_context_commentstring.internal',
+      },
+    }
+  end
+end

--- a/plugin/ts_context_commentstring.vim
+++ b/plugin/ts_context_commentstring.vim
@@ -1,1 +1,0 @@
-lua require('ts_context_commentstring').init()

--- a/utils/minimal_init.lua
+++ b/utils/minimal_init.lua
@@ -16,6 +16,7 @@ vim.opt.rtp:prepend(lazypath)
 vim.opt.updatetime = 100
 
 require('lazy').setup {
+  'JoosepAlviste/nvim-ts-context-commentstring',
   {
     'nvim-treesitter/nvim-treesitter',
     build = ':TSUpdate',
@@ -25,14 +26,8 @@ require('lazy').setup {
         highlight = {
           enable = true,
         },
-        context_commentstring = {
-          enable = true,
-        },
       }
     end,
-    dependencies = {
-      'JoosepAlviste/nvim-ts-context-commentstring',
-    },
   },
   {
     'numToStr/Comment.nvim',

--- a/utils/run_minimal.sh
+++ b/utils/run_minimal.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+export XDG_CONFIG_HOME="${SCRIPT_DIR}/.testenv/config"
+export XDG_DATA_HOME="${SCRIPT_DIR}/.testenv/data"
+export XDG_STATE_HOME="${SCRIPT_DIR}/.testenv/state"
+export XDG_RUNTIME_DIR="${SCRIPT_DIR}/.testenv/run"
+export XDG_CACHE_HOME="${SCRIPT_DIR}/.testenv/cache"
+
+mkdir -p "${XDG_CONFIG_HOME}/nvim"
+mkdir -p "${XDG_DATA_HOME}/nvim"
+mkdir -p "${XDG_STATE_HOME}/nvim"
+mkdir -p "${XDG_RUNTIME_DIR}/nvim"
+mkdir -p "${XDG_CACHE_HOME}/nvim"
+
+nvim -u "${SCRIPT_DIR}/minimal_init.lua" "${SCRIPT_DIR}/minimal_init.lua"


### PR DESCRIPTION
With 0.9 being the minimal version for this plugin, nvim-treesitter is quite literally a fifth wheel for its functionality. It installs and updates parsers, but everything this plugin needs to operate afterwards is available in the core `vim.treesitter` utilities set.

I also borrowed a test setup from aerial.nvim, to create a minimal setup launcher bash script that truly isolates minimal config from main user configuration.