### PR TITLE
fix: remove repeated word in deprecation message

### DIFF
--- a/lua/ts_context_commentstring/internal.lua
+++ b/lua/ts_context_commentstring/internal.lua
@@ -134,7 +134,7 @@ end
 function M.attach()
   vim.deprecate(
     'context_commentstring nvim-treesitter module',
-    "use require('ts_context_commentstring').setup {} and set vim.g.skip_ts_context_commentstring_module = true to speed up loading",
+    "require('ts_context_commentstring').setup {} and set vim.g.skip_ts_context_commentstring_module = true to speed up loading",
     'in the future',
     'ts_context_commentstring'
   )


### PR DESCRIPTION
This PR removes the double appearance of the `use` word in a deprecation message.

Message before the PR:
<img width="1719" alt="Screenshot 2023-11-24 at 11 54 37" src="https://github.com/JoosepAlviste/nvim-ts-context-commentstring/assets/56588510/9705b8ba-af72-4424-9f07-cf7078ef0ccd">
