### PR TITLE
Configure plugin via global variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,15 @@ require('lazy').setup {
 Defaults work out of the box.  
 Set `vim.g.skip_ts_context_commentstring_module = true` somewhere in your configuration to skip backwards compatibility routines and speed up loading.
 
-If you want to change the configuration, call the `setup` function of this plugin, e.g.:
+If you want to change the configuration, provide custom overrides in `vim.g.ts_context_commentstring_config` before it's loaded
+
+```lua
+vim.g.ts_context_commentstring_config = {
+  enable_autocmd = false,
+}
+```
+
+Or call the `setup` function of this plugin, e.g.:
 
 ```lua
 require('ts_context_commentstring').setup {

--- a/doc/nvim-ts-context-commentstring.txt
+++ b/doc/nvim-ts-context-commentstring.txt
@@ -55,7 +55,15 @@ This plugin initializes using default **plugin** system.
 If you need to disable auto-initialization, set
 `g:loaded_ts_context_commentstring` to non-zero value.
 
-Custom configuration can be supplied using `setup` function:
+Custom configuration can be supplied by populating
+`vim.g.ts_context_commentstring_config` before plugin is loaded
+>lua
+  vim.g.ts_context_commentstring_config = {
+    -- ... configuration here
+  }
+<
+
+Or using `setup` function:
 >lua
   require('ts_context_commentstring').setup {
     -- ... configuration here
@@ -65,7 +73,7 @@ Custom configuration can be supplied using `setup` function:
 Support for more languages can be added quite easily by passing a `languages` (formerly the now deprecated `config`) table
 when configuring the plugin:
 >lua
-  require('ts_context_commentstring').setup {
+  vim.g.ts_context_commentstring_config = {
     languages = {
       css = '// %s',
     },
@@ -82,7 +90,7 @@ Treesitter nodes. Each node can have its own unique commenting style. For
 example, here's how the default configuration for `javascript` would look 
 like:
 >lua
-  require('ts_context_commentstring').setup {
+  vim.g.ts_context_commentstring_config = {
     languages = {
       javascript = {
         __default = '// %s',
@@ -107,7 +115,7 @@ Additionally, it is possible to have each 'commentstring' configuration be a
 table with custom keys. This can be used to configure separate single and 
 multi-line comment styles (useful when integrating with a commenting plugin):
 >lua
-  require('ts_context_commentstring').setup {
+  vim.g.ts_context_commentstring_config = {
     languages = {
       typescript = { __default = '// %s', __multiline = '/* %s */' },
     },
@@ -134,7 +142,7 @@ integrations. There are some useful helper functions exported from
 If you want to calculate your own 'commentstring' you are able to do so with
 the `custom_calculation` option:
 >lua
-  require('ts_context_commentstring').setup {
+  vim.g.ts_context_commentstring_config = {
     custom_calculation = function(node, language_tree)
       -- ...
     end,

--- a/lua/ts_context_commentstring.lua
+++ b/lua/ts_context_commentstring.lua
@@ -1,9 +1,9 @@
 local M = {}
 
----Set up non-default configuration
----@param config ts_context_commentstring.Config
+---Re-read global configuration or apply explicit override
+---@param config ts_context_commentstring.Config|nil
 function M.setup(config)
-  require('ts_context_commentstring.config').update(config)
+  require('ts_context_commentstring.config').setup(config or vim.g.ts_context_commentstring_config)
 end
 
 ---Calculate the commentstring based on the current location of the cursor.

--- a/lua/ts_context_commentstring/internal.lua
+++ b/lua/ts_context_commentstring/internal.lua
@@ -20,7 +20,7 @@ function M.setup_buffer(bufnr)
 
   -- If vim-commentary is installed, set up mappings for it
   if vim.g.loaded_commentary == 1 then
-    require('ts_context_commentstring.integrations.vim_commentary').set_up_maps(config.config.commentary_integration)
+    require('ts_context_commentstring.integrations.vim_commentary').set_up_maps(config.commentary_integration())
   end
 
   if enable_autocmd then
@@ -53,14 +53,15 @@ function M.calculate_commentstring(args)
   local key = args.key or '__default'
   local location = args.location or nil
 
-  local node, language_tree =
-    utils.get_node_at_cursor_start_of_line(vim.tbl_keys(config.get_languages_config()), location)
+  local node, language_tree = utils.get_node_at_cursor_start_of_line(config.configured_languages(), location)
 
   if not node and not language_tree then
+    ---@cast node -nil
+    ---@cast language_tree -nil
     return nil
   end
 
-  local custom_calculation = config.config.custom_calculation
+  local custom_calculation = config.custom_calculation()
   if custom_calculation then
     local commentstring = custom_calculation(node, language_tree)
     if commentstring then
@@ -69,7 +70,7 @@ function M.calculate_commentstring(args)
   end
 
   local language = language_tree:lang()
-  local language_config = config.get_languages_config()[language]
+  local language_config = config.for_language(language)
 
   return M.check_node(node, language_config, key)
 end
@@ -100,7 +101,7 @@ end
 ---check its parent node.
 ---
 ---@param node table
----@param language_config ts_context_commentstring.LanguageConfig
+---@param language_config ts_context_commentstring.LanguageConfig|nil
 ---@param commentstring_key string
 ---
 ---@return string | nil


### PR DESCRIPTION
This change allows setting `vim.g.ts_context_commentstring_config` somewhere in, for example, `~/.config/nvim/plugin/ts_commentstring_config.lua` and have the plugin just work without any need to explicitly set it up.

The configuration is read when config.lua is loaded, e.g. on the first `require('ts_context_commentstring.config')`.