### PR TITLE
Support for HTMLDjango with Non-Nested Language Option

### DIFF
--- a/doc/nvim-ts-context-commentstring.txt
+++ b/doc/nvim-ts-context-commentstring.txt
@@ -22,6 +22,7 @@ language tree (see `lua/ts_context_commentstring/internal.lua`):
 - `graphql`
 - `handlebars`
 - `html`
+- `htmldjango`
 - `javascript`
 - `lua`
 - `nix`
@@ -147,6 +148,10 @@ could be used for context like figuring out which language you should use a
 node is. You need to return a 'commentstring' in the `custom_calculation` if you 
 want it to be set.
 
+The `not_nested_languages` table allows you to halt the search for nested
+languages at a specified language. This functionality proves beneficial,
+for instance, in scenarios such as HTML with Django, where you may want
+to include Django comments while excluding HTML content.
 
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:

--- a/lua/ts_context_commentstring/config.lua
+++ b/lua/ts_context_commentstring/config.lua
@@ -40,6 +40,7 @@ local M = {}
 ---@field enable_autocmd? boolean
 ---@field custom_calculation? ts_context_commentstring.CustomCalculation
 ---@field languages? ts_context_commentstring.LanguagesConfig
+---@field not_nested_languages? table<string, boolean>
 ---@field config? ts_context_commentstring.LanguagesConfig
 ---@field commentary_integration? ts_context_commentstring.CommentaryConfig
 

--- a/lua/ts_context_commentstring/config.lua
+++ b/lua/ts_context_commentstring/config.lua
@@ -116,7 +116,7 @@ M.config = {
   },
 
   not_nested_languages = {
-    -- Languages at wich nesting stops
+    -- Languages at which nesting stops
     htmldjango = true,
   },
 

--- a/lua/ts_context_commentstring/config.lua
+++ b/lua/ts_context_commentstring/config.lua
@@ -68,6 +68,7 @@ M.config = {
     haskell = '-- %s',
     handlebars = '{{! %s }}',
     html = '<!-- %s -->',
+    htmldjango = { __default = '{# %s #}', __multiline = '{% comment %} %s {% endcomment %}' },
     lua = { __default = '-- %s', __multiline = '--[[ %s ]]' },
     nix = { __default = '# %s', __multiline = '/* %s */' },
     php = { __default = '// %s', __multiline = '/* %s */' },
@@ -97,6 +98,11 @@ M.config = {
       statement_block = { __default = '// %s', __multiline = '/* %s */' },
       spread_element = { __default = '// %s', __multiline = '/* %s */' },
     },
+  },
+
+  not_nested_languages = {
+    -- Languages at wich nesting stops
+    htmldjango = true,
   },
 
   ---@deprecated Use the languages configuration instead!

--- a/lua/ts_context_commentstring/internal.lua
+++ b/lua/ts_context_commentstring/internal.lua
@@ -57,7 +57,7 @@ function M.calculate_commentstring(args)
     utils.get_node_at_cursor_start_of_line(
       vim.tbl_keys(config.get_languages_config()),
       config.config.not_nested_languages,
-      slocation
+      location
     )
 
   if not node or not language_tree then

--- a/lua/ts_context_commentstring/internal.lua
+++ b/lua/ts_context_commentstring/internal.lua
@@ -54,7 +54,11 @@ function M.calculate_commentstring(args)
   local location = args.location or nil
 
   local node, language_tree =
-    utils.get_node_at_cursor_start_of_line(vim.tbl_keys(config.get_languages_config()), location)
+    utils.get_node_at_cursor_start_of_line(
+      vim.tbl_keys(config.get_languages_config()),
+      config.config.not_nested_languages,
+      slocation
+    )
 
   if not node and not language_tree then
     return nil

--- a/lua/ts_context_commentstring/internal.lua
+++ b/lua/ts_context_commentstring/internal.lua
@@ -53,12 +53,11 @@ function M.calculate_commentstring(args)
   local key = args.key or '__default'
   local location = args.location or nil
 
-  local node, language_tree =
-    utils.get_node_at_cursor_start_of_line(
-      vim.tbl_keys(config.get_languages_config()),
-      config.config.not_nested_languages,
-      location
-    )
+  local node, language_tree = utils.get_node_at_cursor_start_of_line(
+    vim.tbl_keys(config.get_languages_config()),
+    config.config.not_nested_languages,
+    location
+  )
 
   if not node or not language_tree then
     return nil

--- a/lua/ts_context_commentstring/utils.lua
+++ b/lua/ts_context_commentstring/utils.lua
@@ -76,7 +76,8 @@ end
 ---
 ---@param only_languages string[] List of languages to filter for, all
 ---  other languages will be ignored.
----@param not_nested_languages string[] List of languages which stop nesting
+---@param not_nested_languages table<string, boolean> List of languages which
+---  stop nesting
 ---@param location? ts_context_commentstring.Location location Line, column
 ---  where to start traversing the tree. Defaults to cursor start of line.
 ---  This usually makes the most sense when commenting the whole line.

--- a/lua/ts_context_commentstring/utils.lua
+++ b/lua/ts_context_commentstring/utils.lua
@@ -76,13 +76,18 @@ end
 ---
 ---@param only_languages string[] List of languages to filter for, all
 ---  other languages will be ignored.
+---@param not_nested_languages string[] List of languages which stop nesting
 ---@param location? ts_context_commentstring.Location location Line, column
 ---  where to start traversing the tree. Defaults to cursor start of line.
 ---  This usually makes the most sense when commenting the whole line.
 ---
 ---@return table|nil node, table|nil language_tree Node and language tree for the
 ---  location
-function M.get_node_at_cursor_start_of_line(only_languages, location)
+function M.get_node_at_cursor_start_of_line(
+    only_languages,
+    not_nested_languages,
+    location
+  )
   if not M.is_treesitter_active() then
     return
   end
@@ -99,7 +104,9 @@ function M.get_node_at_cursor_start_of_line(only_languages, location)
   local language_tree = vim.treesitter.get_parser()
   -- Get the smallest supported language's tree with nodes inside the given range
   language_tree:for_each_tree(function(_, ltree)
-    if ltree:contains(range) and vim.tbl_contains(only_languages, ltree:lang()) then
+    if ltree:contains(range)
+        and vim.tbl_contains(only_languages, ltree:lang())
+        and not not_nested_languages[language_tree:lang()] then
       language_tree = ltree
     end
   end)

--- a/lua/ts_context_commentstring/utils.lua
+++ b/lua/ts_context_commentstring/utils.lua
@@ -84,11 +84,7 @@ end
 ---
 ---@return TSNode|nil node, vim.treesitter.LanguageTree|nil language_tree Node
 ---   and language tree for the location
-function M.get_node_at_cursor_start_of_line(
-    only_languages,
-    not_nested_languages,
-    location
-  )
+function M.get_node_at_cursor_start_of_line(only_languages, not_nested_languages, location)
   if not M.is_treesitter_active() then
     return
   end
@@ -105,9 +101,11 @@ function M.get_node_at_cursor_start_of_line(
   local language_tree = vim.treesitter.get_parser()
   -- Get the smallest supported language's tree with nodes inside the given range
   language_tree:for_each_tree(function(_, ltree)
-    if ltree:contains(range)
-        and vim.tbl_contains(only_languages, ltree:lang())
-        and not not_nested_languages[language_tree:lang()] then
+    if
+      ltree:contains(range)
+      and vim.tbl_contains(only_languages, ltree:lang())
+      and not not_nested_languages[language_tree:lang()]
+    then
       language_tree = ltree
     end
   end)


### PR DESCRIPTION
This pull request introduces support for comments in the HTMLDjango template language. While the detection of nested languages and formatting comments accordingly is generally advantageous, there are cases where it may be counterproductive, especially in file types like HTMLDjango templates.

In HTMLDjango templates, it is preferable to utilize Django template comments not only within HTML but also in JavaScript and CSS. These comments effectively exclude code from rendering and prove beneficial. The proposed change becomes essential for commenting on template control statements, addressing a limitation in the existing functionality.

Please review and consider merging this pull request to enhance the plugin's compatibility with HTMLDjango templates.