### PR TITLE
feat: add basic templ support

### DIFF
--- a/lua/ts_context_commentstring/config.lua
+++ b/lua/ts_context_commentstring/config.lua
@@ -99,6 +99,10 @@ M.config = {
       statement_block = { __default = '// %s', __multiline = '/* %s */' },
       spread_element = { __default = '// %s', __multiline = '/* %s */' },
     },
+    templ = {
+      __default = '// %s',
+      component_declaration = '<!-- %s -->',
+    },
   },
 
   ---@deprecated Use the languages configuration instead!


### PR DESCRIPTION
Added basic support for templ files. Docs for templ commenting here: https://templ.guide/syntax-and-usage/comments

In general we are using html-style comments inside components, and go-style comments outside.