### PR TITLE
Feat: Add kotlin support

### DIFF
--- a/lua/ts_context_commentstring/config.lua
+++ b/lua/ts_context_commentstring/config.lua
@@ -88,6 +88,7 @@ M.config = {
     vim = '" %s',
     vue = '<!-- %s -->',
     zsh = '# %s',
+    kotlin = { __default = '// %s', __multiline = '/* %s */' },
 
     -- Languages that can have multiple types of comments
     tsx = {


### PR DESCRIPTION
When I used the PR for Kotlin support that I opened in lazyvim, I found that the Kotlin commentstring is empty.