### PR TITLE
Update config.lua - add Powershell multiline comments

### DIFF
--- a/lua/ts_context_commentstring/config.lua
+++ b/lua/ts_context_commentstring/config.lua
@@ -80,6 +80,7 @@ M.config = {
     lua = { __default = '-- %s', __multiline = '--[[ %s ]]' },
     nix = { __default = '# %s', __multiline = '/* %s */' },
     php = { __default = '// %s', __multiline = '/* %s */' },
+    powershell = { __default = "# %s", __multiline = "<# %s #>" },
     python = { __default = '# %s', __multiline = '""" %s """' },
     rego = '# %s',
     rescript = { __default = '// %s', __multiline = '/* %s */' },


### PR DESCRIPTION
Powershell uses <# %s #> for multiline comments
I use Neovim with LazyVim which uses blink.cmp for the LSP as far as I can tell. I'm quite new to all this. 

Treesitter does have a Powershell parser listed here https://github.com/tree-sitter/tree-sitter/wiki/List-of-parsers but I think everyone uses the powershell_es LSP instead. I installed powershell_es using Mason and it's working well. 

I've created a plugin file for this with the change and tested it and it didn't work (good chance I did something wrong), but figured I'd give you the info anyway.