### PR TITLE
Fix for updated treesitter api changes in neovim nightly

### DIFF
--- a/lua/ts_context_commentstring/utils.lua
+++ b/lua/ts_context_commentstring/utils.lua
@@ -7,6 +7,12 @@ local fn = vim.fn
 
 local M = {}
 
+---@param bufnr? number
+---@return vim.treesitter.LanguageTree|nil
+local function get_parser(bufnr)
+  return vim.treesitter.get_parser(bufnr or 0, nil, { error = false })
+end
+
 ---Get the location of the cursor to be used to get the treesitter node
 ---function.
 ---
@@ -54,12 +60,7 @@ end
 ---@return boolean
 ---@param bufnr? number
 function M.is_treesitter_active(bufnr)
-  bufnr = bufnr or 0
-
-  -- get_parser will throw an error if Treesitter is not set up for the buffer
-  local ok, _ = pcall(vim.treesitter.get_parser, bufnr)
-
-  return ok
+  return get_parser(bufnr) ~= nil
 end
 
 ---Get the node that is on the given location (default first non-whitespace
@@ -98,7 +99,10 @@ function M.get_node_at_cursor_start_of_line(only_languages, not_nested_languages
   }
 
   -- default to top level language tree
-  local language_tree = vim.treesitter.get_parser()
+  local language_tree = get_parser()
+  if not language_tree then
+    return
+  end
   -- Get the smallest supported language's tree with nodes inside the given range
   language_tree:for_each_tree(function(_, ltree)
     if


### PR DESCRIPTION
With a recent update to Neovim Nightly, I started getting the current issue constantly:

```
Error in CursorHold Autocommands for "<buffer=4>":
Lua callback: ...ext-commentstring/lua/ts_context_commentstring/utils.lua:103: attempt to index local 'language_tree' (a nil value)
stack traceback:
        ...ext-commentstring/lua/ts_context_commentstring/utils.lua:103: in function 'get_node_at_cursor_start_of_line'
        ...-commentstring/lua/ts_context_commentstring/internal.lua:56: in function 'calculate_commentstring'
        ...-commentstring/lua/ts_context_commentstring/internal.lua:89: in function 'update_commentstring'
        ...-commentstring/lua/ts_context_commentstring/internal.lua:33: in function <...-commentstring/lua/ts_context_commentstring/i
nternal.lua:32>

```

I debugged the issue using codex 5.4 and came up with the following fixes in this commit.  I have very little knowledge of Lua or neovim internals to know whether this is the correct fix.

From my testing, neovim nightly and latest stable work just fine with these changes.