### PR TITLE
Add nil check for language_tree in utils.lua

### DIFF
--- a/lua/ts_context_commentstring/utils.lua
+++ b/lua/ts_context_commentstring/utils.lua
@@ -101,18 +101,20 @@ function M.get_node_at_cursor_start_of_line(only_languages, not_nested_languages
   -- default to top level language tree
   local language_tree = vim.treesitter.get_parser()
   -- Get the smallest supported language's tree with nodes inside the given range
-  language_tree:for_each_tree(function(_, ltree)
-    if
-      ltree:contains(range)
-      and vim.tbl_contains(only_languages, ltree:lang())
-      and not not_nested_languages[language_tree:lang()]
-    then
-      language_tree = ltree
-    end
-  end)
-
-  local node = language_tree:named_node_for_range(range)
-  return node, language_tree
+  if language_tree ~= nil then
+    language_tree:for_each_tree(function(_, ltree)
+      if
+        ltree:contains(range)
+        and vim.tbl_contains(only_languages, ltree:lang())
+        and not not_nested_languages[language_tree:lang()]
+      then
+        language_tree = ltree
+      end
+    end)
+    local node = language_tree:named_node_for_range(range)
+    return node, language_tree
+  end
+  return nil, nil
 end
 
 return M


### PR DESCRIPTION
Add nil check for language_tree before processing trees. Without this check, certain file types that haven't been configured such as `.env` files returned an error of trying to access nil valued language_tree variable. Even moving the cursor caused the error to keep respawning.
I checked the usage of the given function and noticed there is a nil check where it is used, for both `node` and `language_tree` in `internal.lua`, so it shouldn't cause any new error messages or break that it wasn't already.